### PR TITLE
Deprecated `traefik_environment_variables_additional_variables`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -102,18 +102,6 @@ traefik_config_certificatesResolvers_acme_dnsChallenge_resolvers: []
 # traefik_config_certificatesResolvers_acme_dnsChallenge_resolvers:
 #  - "root-dns.netcup.net"
 #  - "second-dns.netcup.net"
-# traefik_environment_variables_additional_variables: |
-#   NETCUP_CUSTOMER_NUMBER=12345
-#   NETCUP_API_KEY=api_key
-#   NETCUP_API_PASSWORD=password
-
-# Additional environment variables to pass to the container.
-#
-# Example:
-# traefik_environment_variables_additional_variables: |
-#   VARIABLE_1=value
-#   VARIABLE_2=value
-traefik_environment_variables_additional_variables: ''
 
 # Controls whether the web entrypoint is enabled
 traefik_config_entrypoint_web_enabled: true
@@ -434,12 +422,15 @@ traefik_provider_configuration_extension: "{{ traefik_provider_configuration_ext
 # You most likely don't need to touch this variable. Instead, see `traefik_provider_configuration_yaml`.
 traefik_provider_configuration: "{{ traefik_provider_configuration_yaml | from_yaml | combine(traefik_provider_configuration_extension, recursive=True) }}"
 
-# traefik_environment_variables holds a string with environment variable to pass to Traefik.
+# traefik_environment_variables contains a multiline string with environment variables to pass to Traefik.
 #
 # Example:
 # traefik_environment_variables: |
 #   TRAEFIK_ACCESSLOG=true
 #   TRAEFIK_API=true
+#   NETCUP_CUSTOMER_NUMBER=12345
+#   NETCUP_API_KEY=api_key
+#   NETCUP_API_PASSWORD=password
 traefik_environment_variables: ''
 
 # traefik_labels_additional_labels contains a multiline string with additional labels to add to the container label file.

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -48,14 +48,6 @@
       become: false
       delegate_to: 127.0.0.1
 
-- name: Ensure Traefik environment variables installed
-  ansible.builtin.copy:
-    content: "{{ traefik_environment_variables }}"
-    dest: "{{ traefik_config_dir_path }}/env"
-    owner: "{{ traefik_uid }}"
-    group: "{{ traefik_gid }}"
-    mode: 0640
-
 - name: Ensure Traefik support files installed
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"

--- a/tasks/validate_config.yml
+++ b/tasks/validate_config.yml
@@ -12,6 +12,7 @@
     - {'old': 'traefik_config_letsencrypt_use_staging', 'new': 'traefik_config_certificatesResolvers_acme_use_staging'}
     - {'old': 'traefik_config_letsencrypt_httpChallenge_entrypoint', 'new': 'traefik_config_certificatesResolvers_acme_httpChallenge_entrypoint'}
     - {'old': 'traefik_config_certificatesResolvers_acme_email', 'new': '<removed as no longer necessary - see https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/4014>'}
+    - {'old': 'traefik_environment_variables_additional_variables', 'new': 'traefik_environment_variables'}
 
 - name: Fail if required Traefik settings not defined
   ansible.builtin.fail:

--- a/templates/env.j2
+++ b/templates/env.j2
@@ -1,1 +1,1 @@
-{{ traefik_environment_variables_additional_variables }}
+{{ traefik_environment_variables }}


### PR DESCRIPTION
Deprecated `traefik_environment_variables_additional_variables` in favor of `traefik_environment_variables`

Tested & verified working

Resolves https://github.com/mother-of-all-self-hosting/ansible-role-traefik/issues/5