### PR TITLE
Support additional docker volumes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,13 @@ traefik_container_additional_networks: "{{ (traefik_container_additional_network
 traefik_container_additional_networks_auto: []
 traefik_container_additional_networks_custom: []
 
+# A list of additional "volumes" to mount in the container.
+# This list gets populated dynamically at runtime. You can provide a different default value,
+# if you wish to mount your own files into the container.
+# Contains definition objects like this: `{"type": "bind", "src": "/outside", "dst": "/inside", "options": "readonly"}.
+# See the `--mount` documentation for the `docker run` command.
+traefik_container_additional_volumes: []
+
 # A list of extra arguments to pass to the container
 traefik_container_extra_arguments: "{{ traefik_container_extra_arguments_auto + traefik_container_extra_arguments_custom }}"
 traefik_container_extra_arguments_auto: []

--- a/templates/traefik.service.j2
+++ b/templates/traefik.service.j2
@@ -63,6 +63,9 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% if traefik_plugin_support_enabled %}
 			--mount type=bind,src={{ traefik_plugins_dir_path }},dst=/plugins-storage \
 			{% endif %}
+			{% for volume in traefik_container_additional_volumes %}
+			--mount type={{ volume.type | default('bind' if '/' in volume.src else 'volume') }},src={{ volume.src }},dst={{ volume.dst }}{{ (',' + volume.options) if volume.options else '' }} \
+			{% endfor %}
 			{% if traefik_container_extra_arguments | length > 0 %}
 			{{ traefik_container_extra_arguments | join(" ") }} \
 			{% endif %}


### PR DESCRIPTION
Let's support additional docker volumes.

### My usecase
I'd like to be able to export traefik access logs outside of the container. Access log changes in separate PR: #8