### PR TITLE
Additional accesslog options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,6 +62,15 @@ traefik_config_log_level: INFO
 # Controls whether logs for incoming requests are collected
 traefik_config_accessLog_enabled: true
 
+# Controls the access log format (json or common)
+traefik_config_accessLog_format: "common"
+
+# Controls the access log file path
+traefik_config_accessLog_filePath: ""
+
+# Controls the access log buffering size
+traefik_config_accessLog_bufferingSize: 100
+
 # Controls whether Prometheus metrics will be exposed on a new metrics entrypoint.
 # See traefik_config_entrypoint_metrics_enabled
 traefik_config_metrics_prometheus_enabled: false

--- a/templates/traefik.yml.j2
+++ b/templates/traefik.yml.j2
@@ -17,9 +17,7 @@ accessLog:
   {% if traefik_config_accessLog_filePath %}
   filePath: {{ traefik_config_accessLog_filePath | to_json }}
   {% endif %}
-  {% if traefik_config_accessLog_bufferingSize %}
   bufferingSize: {{ traefik_config_accessLog_bufferingSize | to_json }}
-  {% endif %}
 {% endif %}
 
 api:

--- a/templates/traefik.yml.j2
+++ b/templates/traefik.yml.j2
@@ -14,10 +14,10 @@ log:
 {% if traefik_config_accessLog_enabled %}
 accessLog:
   format: {{ traefik_config_accessLog_format | to_json }}
-  {% if traefik_config_accessLog_filePath is defined %}
+  {% if traefik_config_accessLog_filePath %}
   filePath: {{ traefik_config_accessLog_filePath | to_json }}
   {% endif %}
-  {% if traefik_config_accessLog_bufferingSize is defined %}
+  {% if traefik_config_accessLog_bufferingSize %}
   bufferingSize: {{ traefik_config_accessLog_bufferingSize | to_json }}
   {% endif %}
 {% endif %}

--- a/templates/traefik.yml.j2
+++ b/templates/traefik.yml.j2
@@ -12,7 +12,14 @@ log:
   level: {{ traefik_config_log_level | to_json }}
 
 {% if traefik_config_accessLog_enabled %}
-accessLog: {}
+accessLog:
+  format: {{ traefik_config_accessLog_format | to_json }}
+  {% if traefik_config_accessLog_filePath is defined %}
+  filePath: {{ traefik_config_accessLog_filePath | to_json }}
+  {% endif %}
+  {% if traefik_config_accessLog_bufferingSize is defined %}
+  bufferingSize: {{ traefik_config_accessLog_bufferingSize | to_json }}
+  {% endif %}
 {% endif %}
 
 api:


### PR DESCRIPTION
Add some accesslog options.
`traefik_config_accessLog_format` is purposefully set to its default `common`, to populate `templates/traefik.yml.j2` correctly.

### My usecase
Paired with #7, it will be possible to conveniently export traefik accesslogs into other containers.